### PR TITLE
Add documentation pages

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: API Overview
+permalink: /docs/api-overview/
+---
+
+This is a placeholder page describing the fictional GreenGrid API. It provides a high level overview of how to interact with the service.
+

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Authentication Guide
+permalink: /docs/authentication/
+---
+
+This is a fake document explaining how to obtain and use API credentials for the GreenGrid service.
+

--- a/index.md
+++ b/index.md
@@ -4,3 +4,9 @@
 
 layout: home
 ---
+
+Welcome to the GreenGrid API documentation site. Use the links below to explore the available guides.
+
+- [API Overview]({{ site.baseurl }}/docs/api-overview/)
+- [Authentication Guide]({{ site.baseurl }}/docs/authentication/)
+


### PR DESCRIPTION
## Summary
- create `docs` folder with two placeholder API docs
- link to the docs from the home page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847558a345c8330b6281ee3e4339faf